### PR TITLE
fix: modify isMultiline prop to generate textarea node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mirrormedia/html-draft-editor",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "description": "html-draft-editor",
     "main": "lib/index.js",
     "scripts": {

--- a/src/lib/editor/mixins/entity-editing-block-mixin.js
+++ b/src/lib/editor/mixins/entity-editing-block-mixin.js
@@ -237,7 +237,7 @@ export class EntityEditingBlock extends Component {
                     type="text"
                     value={value ? value : ''}
                     onChange={onChange}
-                    multiline={type === 'textarea' ? 'true' : 'false'}
+                    isMultiline={type === 'textarea'}
                     placeholder={'Enter ' + field}
                     name={'form-input-' + field}
                 />


### PR DESCRIPTION
1. 修正原先 `isMultiline` 的傳入錯誤，使 `<textarea>` 能正確產生。 
2. 影響的欄位包含 `embed-code`、`quote-by` 與 `youtube`。